### PR TITLE
Highlight hexadecimal and other number literals

### DIFF
--- a/v-udl.xml
+++ b/v-udl.xml
@@ -16,9 +16,9 @@ That should be it :D
         </Settings>
         <KeywordLists>
             <Keywords name="Comments">03/* 03/** 04*/ 04*/ 00// 01 02</Keywords>
-            <Keywords name="Numbers, prefix1"></Keywords>
-            <Keywords name="Numbers, prefix2"></Keywords>
-            <Keywords name="Numbers, extras1"></Keywords>
+            <Keywords name="Numbers, prefix1">0b 0o</Keywords>
+            <Keywords name="Numbers, prefix2">0x</Keywords>
+            <Keywords name="Numbers, extras1">A B C D E F _ a b c d e f</Keywords>
             <Keywords name="Numbers, extras2"></Keywords>
             <Keywords name="Numbers, suffix1"></Keywords>
             <Keywords name="Numbers, suffix2"></Keywords>


### PR DESCRIPTION
Only hexadecimal literals with underscores will be highlighted right;
decimal, octal, & binary literals with underscores WON'T be highlighted.
This is due to an (unfortunate) limitation of UDL 2.1